### PR TITLE
Fixed restore of qtype options, and error in unit test.

### DIFF
--- a/backup/moodle2/backup_qtype_calculatedformat_plugin.class.php
+++ b/backup/moodle2/backup_qtype_calculatedformat_plugin.class.php
@@ -69,8 +69,7 @@ class backup_qtype_calculatedformat_plugin extends backup_qtype_plugin {
         $calculatedrecord = new backup_nested_element('calculatedformat_record', array('id'), array(
             'answerid', 'tolerance', 'tolerancetype'));
 
-        $calculatedoptions = new backup_nested_element('calculatedformat_options');
-        $calculatedoption = new backup_nested_element('calculatedformat_option', array('id'), array(
+        $calculatedoptions = new backup_nested_element('calculatedformat_options', array('id'), array(
             'synchronize', 'single', 'shuffleanswers', 'correctfeedback',
             'correctfeedbackformat', 'partiallycorrectfeedback', 'partiallycorrectfeedbackformat',
             'incorrectfeedback', 'incorrectfeedbackformat', 'answernumbering',
@@ -85,12 +84,11 @@ class backup_qtype_calculatedformat_plugin extends backup_qtype_plugin {
         $calculatedrecords->add_child($calculatedrecord);
 
         $pluginwrapper->add_child($calculatedoptions);
-        $calculatedoptions->add_child($calculatedoption);
 
         // Set source to populate the data.
         $calculatedrecord->set_source_table('qtype_calculatedfmt',
                 array('questionid' => backup::VAR_PARENTID));
-        $calculatedoption->set_source_table('qtype_calculatedfmt_opts',
+        $calculatedoptions->set_source_table('qtype_calculatedfmt_opts',
                 array('questionid' => backup::VAR_PARENTID));
 
         // Don't need to annotate ids nor files.

--- a/backup/moodle2/restore_qtype_calculatedformat_plugin.class.php
+++ b/backup/moodle2/restore_qtype_calculatedformat_plugin.class.php
@@ -58,8 +58,8 @@ class restore_qtype_calculatedformat_plugin extends restore_qtype_plugin {
         $elepath = $this->get_pathfor('/calculatedformat_records/calculatedformat_record');
         $paths[] = new restore_path_element($elename, $elepath);
 
-        $elename = 'calculatedformat_option';
-        $elepath = $this->get_pathfor('/calculatedformat_options/calculatedformat_option');
+        $elename = 'calculatedformat_options';
+        $elepath = $this->get_pathfor('/calculatedformat_options');
         $paths[] = new restore_path_element($elename, $elepath);
 
         return $paths; // And we return the interesting paths.
@@ -75,8 +75,8 @@ class restore_qtype_calculatedformat_plugin extends restore_qtype_plugin {
         $oldid = $data->id;
 
         // Detect if the question is created or mapped.
-        $oldquestionid   = $this->get_old_parentid('questionid');
-        $newquestionid   = $this->get_new_parentid('questionid');
+        $oldquestionid   = $this->get_old_parentid('question');
+        $newquestionid   = $this->get_new_parentid('question');
         $questioncreated = $this->get_mappingid('question_created', $oldquestionid) ?
                 true : false;
 
@@ -94,15 +94,15 @@ class restore_qtype_calculatedformat_plugin extends restore_qtype_plugin {
     /**
      * Process the qtype/calculatedformat_option element
      */
-    public function process_calculatedformat_option($data) {
+    public function process_calculatedformat_options($data) {
         global $DB;
 
         $data = (object)$data;
         $oldid = $data->id;
 
         // Detect if the question is created or mapped.
-        $oldquestionid   = $this->get_old_parentid('questionid');
-        $newquestionid   = $this->get_new_parentid('questionid');
+        $oldquestionid   = $this->get_old_parentid('question');
+        $newquestionid   = $this->get_new_parentid('question');
         $questioncreated = $this->get_mappingid('question_created', $oldquestionid) ?
                 true : false;
 

--- a/tests/helper.php
+++ b/tests/helper.php
@@ -76,6 +76,7 @@ class qtype_calculatedformat_test_helper extends question_test_helper {
             array()
         );
         $q->synchronised = false;
+        $q->correctanswershowbase = 1;
         $q->correctanswerbase = 10;
         $q->correctanswerlengthint = 1;
         $q->correctanswerlengthfrac = 4;


### PR DESCRIPTION
Dan,

The problem with restore was in the  `get_{old|new}_parentid('questionid');` calls.  `questionid` should be `question`.  I also changed the organization so that the question options are a direct child of the question itself, rather than an array of one options element.  This seemed cleaner to me.

The unit test problem seemed to be an undefined variable, but it's now failing on question answer comparison.  My guess is that the `correctanswershowbase` option isn't working correctly with decimal answers.

Cheers!
